### PR TITLE
Helptext additions

### DIFF
--- a/prescreeners/shared/css/custom-styles.css
+++ b/prescreeners/shared/css/custom-styles.css
@@ -7,7 +7,6 @@
 .subtitle {
   text-align: center;
   margin: 20px 0 40px 0;
-  font-style: italic;
 }
 
 .alert {
@@ -32,12 +31,6 @@
 h1 {
   font-size: 38px;
   margin-bottom: 38px;
-}
-
-h2 {
-  font-weight: normal;
-  font-family: 'Merriweather';
-  font-size: 20px;
 }
 
 .calculator {
@@ -75,7 +68,6 @@ fieldset.usa-fieldset legend {
 
 .label-sub-text {
   color: #2F4F4F;
-  font-size: 14px;
 }
 
 #main {

--- a/prescreeners/va.html
+++ b/prescreeners/va.html
@@ -23,7 +23,10 @@
                 class="usa-form"
                 data-state-or-territory="VA"
                 data-use-emergency-allotment="true">
-            <label class="usa-label" for="household_size" id="household-size-label">Household size:</label>
+            <label class="usa-label" for="household_size" id="household-size-label">Household size</label>
+            <div class="label-sub-text">
+              <em>Your household is the people you live with and buy food with. Include children 21 or younger, parents, and spouses if they live with you.</em>
+            </div>
             <select required class="usa-select" id="household_size" name="household_size">
               <option value>- Select -</option>
               <option value="1">Just me</option>
@@ -116,7 +119,7 @@
             </div>
 
             <label class="usa-label" for="monthly_job_income">
-              Monthly income from a job or from self-employment:
+              Monthly income from a job or from self-employment
             </label>
 
             <div id="monthly_job_income_error_elem"></div>
@@ -129,7 +132,7 @@
             </div>
 
             <label class="usa-label" for="monthly_non_job_income">
-              Monthly income from other sources:
+              Monthly income from other sources
             </label>
             <em class="label-sub-text">
               These could include Social Security, disability, Child Support, Worker's Comp, Unemployment, Pension Income, or other sources of income.
@@ -145,7 +148,7 @@
             </div>
 
             <label class="usa-label" for="resources">
-              Total resources:
+              Total resources
             </label>
             <em class="label-sub-text">
               This means countable resources, like funds in bank accounts. A home is not counted as a resource.
@@ -161,9 +164,11 @@
             </div>
 
             <label class="usa-label" for="dependent_care_costs">
-              Dependent care costs:
+              Dependent care costs
             </label>
-
+            <em class="label-sub-text">
+              These could include the costs of daycare, babysitters, or other child care; fees for before-school and after-school care; costs for special needs care.
+            </em>
             <div id="dependent_care_costs_error_elem"></div>
             <div class="currency_field_wrapper">
               <div class="dollar_sign">$</div>
@@ -174,7 +179,7 @@
 
             <div id="medical_expenses_for_elderly_or_disabled_question" class="hidden">
               <label class="usa-label" for="medical_expenses_for_elderly_or_disabled">
-                Monthly out of pocket medical expenses for household members who are age 60 or older or disabled:
+                Monthly out of pocket medical expenses for household members who are age 60 or older or disabled
               </label>
 
               <div id="medical_expenses_for_elderly_or_disabled_error_elem"></div>
@@ -187,7 +192,7 @@
             </div>
 
             <label class="usa-label" for="court_ordered_child_support_payments">
-              Monthly court-ordered child support payments:
+              Monthly court-ordered child support payments
             </label>
 
             <div id="court_ordered_child_support_payments_error_elem"></div>
@@ -199,7 +204,7 @@
             </div>
 
             <label class="usa-label" for="rent_or_mortgage">
-              Monthly rent or mortgage amount:
+              Monthly rent or mortgage amount
             </label>
 
             <div id="rent_or_mortgage_error_elem"></div>
@@ -211,7 +216,7 @@
             </div>
 
             <label class="usa-label" for="homeowners_insurance_and_taxes">
-              Monthly homeowners insurance and taxes:
+              Monthly homeowners insurance and taxes
             </label>
 
             <div id="homeowners_insurance_and_taxes_error_elem"></div>
@@ -254,7 +259,7 @@
 
             <div id="utility_costs_question">
               <label class="usa-label" for="utility_costs">
-                Monthly utility bills:
+                Monthly utility bills
               </label>
 
               <div id="utility_costs_error_elem"></div>


### PR DESCRIPTION
# Notes 

+ Based on preliminary user testing and conversations with VPLC, add additional helptext for household size and dependent care cost questions.
+ Increase font size on help text for accessibility improvement. 

# Screenshot

<img width="1100" alt="Screen Shot 2020-06-30 at 4 24 50 PM" src="https://user-images.githubusercontent.com/3209501/86178625-41f85d00-baee-11ea-9ced-8ce0db2ec612.png">
