### PR TITLE
Fix async strategies in integration test

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "build": "npx webpack --config webpack.config.js",
     "pa11y": "pa11y-ci ./prescreeners/il.html && pa11y-ci ./prescreeners/va.html",
     "dev-server": "webpack-dev-server --port 8081",
-    "test": "mocha ./test/test.js",
+    "test": "mocha ./test/test.js --timeout 8000",
     "lint": "npx eslint prescreeners/form-controls.js"
   },
   "author": "Alex Soble for 18F",

--- a/test/test.js
+++ b/test/test.js
@@ -37,7 +37,7 @@ describe('VA SNAP prescreener', () => {
         const innerHTML = await page.evaluate(() => document.querySelector('#results').innerHTML);
         const expectedInnerHTML = `<h1>Results:</h1>
             <div class="result-headline">You may be <b>eligible</b> for SNAP benefits.</div>
-            <div class="result-headline">If approved, your benefit could be as much as $194 per month.</div>
+            <div class="result-headline">If approved, your benefit could be as much as $200 per month.</div>
             <div class="result-headline">Apply here: <a href="https://commonhelp.virginia.gov/" target="_blank" rel="noopener noreferrer">https://commonhelp.virginia.gov/</a>.</div>`;
 
         assert.equalIgnoreSpaces(innerHTML, expectedInnerHTML);

--- a/test/test.js
+++ b/test/test.js
@@ -27,7 +27,7 @@ describe('VA SNAP prescreener', () => {
         const innerHTML = await page.evaluate(() => document.querySelector('#results').innerHTML);
         const expectedInnerHTML = `<h1>Results:</h1>
             <div class="result-headline">You may be <b>eligible</b> for SNAP benefits.</div>
-            <div class="result-headline">If approved, your benefit could be as much as $200 per month.</div>
+            <div class="result-headline">If approved, your benefit could be as much as $194 per month.</div>
             <div class="result-headline">Apply here: <a href="https://commonhelp.virginia.gov/" target="_blank" rel="noopener noreferrer">https://commonhelp.virginia.gov/</a>.</div>`;
 
         try {

--- a/test/test.js
+++ b/test/test.js
@@ -30,10 +30,13 @@ describe('VA SNAP prescreener', () => {
             <div class="result-headline">If approved, your benefit could be as much as $200 per month.</div>
             <div class="result-headline">Apply here: <a href="https://commonhelp.virginia.gov/" target="_blank" rel="noopener noreferrer">https://commonhelp.virginia.gov/</a>.</div>`;
 
-        assert.equalIgnoreSpaces(innerHTML, expectedInnerHTML);
-
-        await page.close();
-        await browser.close();
+        try {
+            assert.equalIgnoreSpaces(innerHTML, expectedInnerHTML);
+        }
+        finally {
+            await page.close();
+            await browser.close();
+        }
     });
 
     it('shows the correct results HTML for a 2-person eligible household', async () => {

--- a/test/test.js
+++ b/test/test.js
@@ -65,10 +65,13 @@ describe('VA SNAP prescreener', () => {
             <div class="result-headline">If approved, your benefit could be as much as $355 per month.</div>
             <div class="result-headline">Apply here: <a href="https://commonhelp.virginia.gov/" target="_blank" rel="noopener noreferrer">https://commonhelp.virginia.gov/</a>.</div>`;
 
-        assert.equalIgnoreSpaces(innerHTML, expectedInnerHTML);
-
-        await page.close();
-        await browser.close();
+        try {
+            assert.equalIgnoreSpaces(innerHTML, expectedInnerHTML);
+        }
+        finally {
+            await page.close();
+            await browser.close();
+        }
     });
 
     it('shows the correct results HTML for an ineligible household', async () => {
@@ -94,9 +97,12 @@ describe('VA SNAP prescreener', () => {
         const innerHTML = await page.evaluate(() => document.querySelector('#results').innerHTML);
         const expectedInnerHTML = `<h1>Results:</h1><div class="result-headline">You may not be eligible for SNAP benefits.</div>`;
 
-        assert.equalIgnoreSpaces(innerHTML, expectedInnerHTML);
-
-        await page.close();
-        await browser.close();
+        try {
+            assert.equalIgnoreSpaces(innerHTML, expectedInnerHTML);
+        }
+        finally {
+            await page.close();
+            await browser.close();
+        }
     });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -4,13 +4,23 @@ chai.use(require('chai-string'));
 const assert = chai.assert;
 
 describe('VA SNAP prescreener', () => {
-    it('shows the correct results HTML for a 1-person eligible household', async () => {
-        const browser = await puppeteer.launch();
-        const page = await browser.newPage();
+    before(async () => {
+        browser = await puppeteer.launch();
+        page = await browser.newPage();
+    });
+
+    beforeEach(async () => {
         const file_url = 'http://localhost:8081/prescreeners/va.html';
         await page.goto(file_url);
-
         await page.waitForSelector('#household_size');
+    });
+
+    after(async () => {
+        await page.close();
+        await browser.close();
+    })
+
+    it('shows the correct results HTML for a 1-person eligible household', async () => {
         await page.select('#household_size', '1');
         await page.click('label[for="input__household_includes_elderly_or_disabled_false"]');
         await page.click('label[for="input__all_citizens_question_true"]');
@@ -30,22 +40,10 @@ describe('VA SNAP prescreener', () => {
             <div class="result-headline">If approved, your benefit could be as much as $194 per month.</div>
             <div class="result-headline">Apply here: <a href="https://commonhelp.virginia.gov/" target="_blank" rel="noopener noreferrer">https://commonhelp.virginia.gov/</a>.</div>`;
 
-        try {
-            assert.equalIgnoreSpaces(innerHTML, expectedInnerHTML);
-        }
-        finally {
-            await page.close();
-            await browser.close();
-        }
+        assert.equalIgnoreSpaces(innerHTML, expectedInnerHTML);
     });
 
     it('shows the correct results HTML for a 2-person eligible household', async () => {
-        const browser = await puppeteer.launch();
-        const page = await browser.newPage();
-        const file_url = 'http://localhost:8081/prescreeners/va.html';
-        await page.goto(file_url);
-
-        await page.waitForSelector('#household_size');
         await page.select('#household_size', '2');
         await page.click('label[for="input__household_includes_elderly_or_disabled_false"]');
         await page.click('label[for="input__all_citizens_question_true"]');
@@ -65,22 +63,10 @@ describe('VA SNAP prescreener', () => {
             <div class="result-headline">If approved, your benefit could be as much as $355 per month.</div>
             <div class="result-headline">Apply here: <a href="https://commonhelp.virginia.gov/" target="_blank" rel="noopener noreferrer">https://commonhelp.virginia.gov/</a>.</div>`;
 
-        try {
-            assert.equalIgnoreSpaces(innerHTML, expectedInnerHTML);
-        }
-        finally {
-            await page.close();
-            await browser.close();
-        }
+        assert.equalIgnoreSpaces(innerHTML, expectedInnerHTML);
     });
 
     it('shows the correct results HTML for an ineligible household', async () => {
-        const browser = await puppeteer.launch();
-        const page = await browser.newPage();
-        const file_url = 'http://localhost:8081/prescreeners/va.html';
-        await page.goto(file_url);
-
-        await page.waitForSelector('#household_size');
         await page.select('#household_size', '1');
         await page.click('label[for="input__household_includes_elderly_or_disabled_false"]');
         await page.click('label[for="input__all_citizens_question_true"]');
@@ -97,12 +83,6 @@ describe('VA SNAP prescreener', () => {
         const innerHTML = await page.evaluate(() => document.querySelector('#results').innerHTML);
         const expectedInnerHTML = `<h1>Results:</h1><div class="result-headline">You may not be eligible for SNAP benefits.</div>`;
 
-        try {
-            assert.equalIgnoreSpaces(innerHTML, expectedInnerHTML);
-        }
-        finally {
-            await page.close();
-            await browser.close();
-        }
+        assert.equalIgnoreSpaces(innerHTML, expectedInnerHTML);
     });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -27,7 +27,7 @@ describe('VA SNAP prescreener', () => {
         const innerHTML = await page.evaluate(() => document.querySelector('#results').innerHTML);
         const expectedInnerHTML = `<h1>Results:</h1>
             <div class="result-headline">You may be <b>eligible</b> for SNAP benefits.</div>
-            <div class="result-headline">If approved, your benefit could be as much as $194 per month.</div>
+            <div class="result-headline">If approved, your benefit could be as much as $200 per month.</div>
             <div class="result-headline">Apply here: <a href="https://commonhelp.virginia.gov/" target="_blank" rel="noopener noreferrer">https://commonhelp.virginia.gov/</a>.</div>`;
 
         assert.equalIgnoreSpaces(innerHTML, expectedInnerHTML);

--- a/test/test.js
+++ b/test/test.js
@@ -37,7 +37,7 @@ describe('VA SNAP prescreener', () => {
         const innerHTML = await page.evaluate(() => document.querySelector('#results').innerHTML);
         const expectedInnerHTML = `<h1>Results:</h1>
             <div class="result-headline">You may be <b>eligible</b> for SNAP benefits.</div>
-            <div class="result-headline">If approved, your benefit could be as much as $200 per month.</div>
+            <div class="result-headline">If approved, your benefit could be as much as $194 per month.</div>
             <div class="result-headline">Apply here: <a href="https://commonhelp.virginia.gov/" target="_blank" rel="noopener noreferrer">https://commonhelp.virginia.gov/</a>.</div>`;
 
         assert.equalIgnoreSpaces(innerHTML, expectedInnerHTML);

--- a/test/test.js
+++ b/test/test.js
@@ -4,102 +4,96 @@ chai.use(require('chai-string'));
 const assert = chai.assert;
 
 describe('VA SNAP prescreener', () => {
-    it('shows the correct results HTML for a 1-person eligible household', () => {
-        (async () => {
-            const browser = await puppeteer.launch();
-            const page = await browser.newPage();
-            const file_url = 'http://localhost:8081/prescreeners/va.html';
-            await page.goto(file_url);
+    it('shows the correct results HTML for a 1-person eligible household', async () => {
+        const browser = await puppeteer.launch();
+        const page = await browser.newPage();
+        const file_url = 'http://localhost:8081/prescreeners/va.html';
+        await page.goto(file_url);
 
-            await page.waitForSelector('#household_size');
-            await page.select('#household_size', '1');
-            await page.click('label[for="input__household_includes_elderly_or_disabled_false"]');
-            await page.click('label[for="input__all_citizens_question_true"]');
-            await page.type('#monthly_job_income', '0');
-            await page.type('#monthly_non_job_income', '0');
-            await page.type('#resources', '0');
-            await page.click('#prescreener-form-submit');
+        await page.waitForSelector('#household_size');
+        await page.select('#household_size', '1');
+        await page.click('label[for="input__household_includes_elderly_or_disabled_false"]');
+        await page.click('label[for="input__all_citizens_question_true"]');
+        await page.type('#monthly_job_income', '0');
+        await page.type('#monthly_non_job_income', '0');
+        await page.type('#resources', '0');
+        await page.click('#prescreener-form-submit');
 
-            await page.waitForSelector('.result-headline', {
-                'visible': true,
-                'timeout': 5000
-            });
+        await page.waitForSelector('.result-headline', {
+            'visible': true,
+            'timeout': 5000
+        });
 
-            const innerHTML = await page.evaluate(() => document.querySelector('#results').innerHTML);
-            const expectedInnerHTML = `<h1>Results:</h1>
-                <div class="result-headline">You may be <b>eligible</b> for SNAP benefits.</div>
-                <div class="result-headline">If approved, your benefit could be as much as $194 per month.</div>
-                <div class="result-headline">Apply here: <a href="https://commonhelp.virginia.gov/" target="_blank" rel="noopener noreferrer">https://commonhelp.virginia.gov/</a>.</div>`;
+        const innerHTML = await page.evaluate(() => document.querySelector('#results').innerHTML);
+        const expectedInnerHTML = `<h1>Results:</h1>
+            <div class="result-headline">You may be <b>eligible</b> for SNAP benefits.</div>
+            <div class="result-headline">If approved, your benefit could be as much as $194 per month.</div>
+            <div class="result-headline">Apply here: <a href="https://commonhelp.virginia.gov/" target="_blank" rel="noopener noreferrer">https://commonhelp.virginia.gov/</a>.</div>`;
 
-            assert.equalIgnoreSpaces(innerHTML, expectedInnerHTML);
+        assert.equalIgnoreSpaces(innerHTML, expectedInnerHTML);
 
-            page.close();
-            browser.close();
-        })();
+        await page.close();
+        await browser.close();
     });
 
-    it('shows the correct results HTML for a 2-person eligible household', () => {
-        (async () => {
-            const browser = await puppeteer.launch();
-            const page = await browser.newPage();
-            const file_url = 'http://localhost:8081/prescreeners/va.html';
-            await page.goto(file_url);
+    it('shows the correct results HTML for a 2-person eligible household', async () => {
+        const browser = await puppeteer.launch();
+        const page = await browser.newPage();
+        const file_url = 'http://localhost:8081/prescreeners/va.html';
+        await page.goto(file_url);
 
-            await page.waitForSelector('#household_size');
-            await page.select('#household_size', '2');
-            await page.click('label[for="input__household_includes_elderly_or_disabled_false"]');
-            await page.click('label[for="input__all_citizens_question_true"]');
-            await page.type('#monthly_job_income', '0');
-            await page.type('#monthly_non_job_income', '0');
-            await page.type('#resources', '0');
-            await page.click('#prescreener-form-submit');
+        await page.waitForSelector('#household_size');
+        await page.select('#household_size', '2');
+        await page.click('label[for="input__household_includes_elderly_or_disabled_false"]');
+        await page.click('label[for="input__all_citizens_question_true"]');
+        await page.type('#monthly_job_income', '0');
+        await page.type('#monthly_non_job_income', '0');
+        await page.type('#resources', '0');
+        await page.click('#prescreener-form-submit');
 
-            await page.waitForSelector('.result-headline', {
-                'visible': true,
-                'timeout': 5000
-            });
+        await page.waitForSelector('.result-headline', {
+            'visible': true,
+            'timeout': 5000
+        });
 
-            const innerHTML = await page.evaluate(() => document.querySelector('#results').innerHTML);
-            const expectedInnerHTML = `<h1>Results:</h1>
-                <div class="result-headline">You may be <b>eligible</b> for SNAP benefits.</div>
-                <div class="result-headline">If approved, your benefit could be as much as $355 per month.</div>
-                <div class="result-headline">Apply here: <a href="https://commonhelp.virginia.gov/" target="_blank" rel="noopener noreferrer">https://commonhelp.virginia.gov/</a>.</div>`;
+        const innerHTML = await page.evaluate(() => document.querySelector('#results').innerHTML);
+        const expectedInnerHTML = `<h1>Results:</h1>
+            <div class="result-headline">You may be <b>eligible</b> for SNAP benefits.</div>
+            <div class="result-headline">If approved, your benefit could be as much as $355 per month.</div>
+            <div class="result-headline">Apply here: <a href="https://commonhelp.virginia.gov/" target="_blank" rel="noopener noreferrer">https://commonhelp.virginia.gov/</a>.</div>`;
 
-            assert.equalIgnoreSpaces(innerHTML, expectedInnerHTML);
+        assert.equalIgnoreSpaces(innerHTML, expectedInnerHTML);
 
-            page.close();
-            browser.close();
-        })();
+        await page.close();
+        await browser.close();
     });
 
-    it('shows the correct results HTML for an ineligible household', () => {
-        (async () => {
-            const browser = await puppeteer.launch();
-            const page = await browser.newPage();
-            const file_url = 'http://localhost:8081/prescreeners/va.html';
-            await page.goto(file_url);
+    it('shows the correct results HTML for an ineligible household', async () => {
+        const browser = await puppeteer.launch();
+        const page = await browser.newPage();
+        const file_url = 'http://localhost:8081/prescreeners/va.html';
+        await page.goto(file_url);
 
-            await page.waitForSelector('#household_size');
-            await page.select('#household_size', '1');
-            await page.click('label[for="input__household_includes_elderly_or_disabled_false"]');
-            await page.click('label[for="input__all_citizens_question_true"]');
-            await page.type('#monthly_job_income', '6000');
-            await page.type('#monthly_non_job_income', '0');
-            await page.type('#resources', '0');
-            await page.click('#prescreener-form-submit');
+        await page.waitForSelector('#household_size');
+        await page.select('#household_size', '1');
+        await page.click('label[for="input__household_includes_elderly_or_disabled_false"]');
+        await page.click('label[for="input__all_citizens_question_true"]');
+        await page.type('#monthly_job_income', '6000');
+        await page.type('#monthly_non_job_income', '0');
+        await page.type('#resources', '0');
+        await page.click('#prescreener-form-submit');
 
-            await page.waitForSelector('.result-headline', {
-                'visible': true,
-                'timeout': 5000
-            });
+        await page.waitForSelector('.result-headline', {
+            'visible': true,
+            'timeout': 5000
+        });
 
-            const innerHTML = await page.evaluate(() => document.querySelector('#results').innerHTML);
-            const expectedInnerHTML = `<h1>Results:</h1><div class="result-headline">You may not be eligible for SNAP benefits.</div>`;
+        const innerHTML = await page.evaluate(() => document.querySelector('#results').innerHTML);
+        const expectedInnerHTML = `<h1>Results:</h1><div class="result-headline">You may not be eligible for SNAP benefits.</div>`;
 
-            assert.equalIgnoreSpaces(innerHTML, expectedInnerHTML);
+        assert.equalIgnoreSpaces(innerHTML, expectedInnerHTML);
 
-            page.close();
-            browser.close();
-        })();
+        await page.close();
+        await browser.close();
     });
 });


### PR DESCRIPTION
# Notes on `test.js` improvements:

+ Remove unnecessary anonymous functions within `it` blocks
+ This allows us to use `before`, `beforeEach`, `after` to reduce duplication in the code
+ ... which allows us to reuse page and browser across tests
+ Make sure to `await` for page and browser to close

# Acknowledgements:

+ Thank you for the pairing advice and wisdom @adunkman :D
