### PR TITLE
Remove position: fixed code from footer; does not work in IE11

### DIFF
--- a/prescreeners/shared/css/custom-styles.css
+++ b/prescreeners/shared/css/custom-styles.css
@@ -110,8 +110,6 @@ footer {
   color: white;
   background-color: #1B1349;
   text-align: center;
-  position: fixed;
-  bottom: 0;
   width: 100%;
   padding: 16px;
 }


### PR DESCRIPTION
## Federalist preview link

https://federalist-1c734efa-8e7a-40ed-9b1e-432001a347e9.app.cloud.gov/preview/18f/snap-js-prescreener-prototypes/ars/remove-position-fixed-footer/prescreeners/va.html

## Notes

Checked in IE 11, Chrome, Firefox, and Safari. 