### PR TITLE
Use more specific element ID for footer CSS

### DIFF
--- a/prescreeners/il.html
+++ b/prescreeners/il.html
@@ -306,7 +306,7 @@
         <div class="tablet:grid-col"></div>
       </div>
     </div>
-    <footer>
+    <footer id="snap-calculator-footer">
       Questions about your result? Confused about anything on this form? Reach out: <a href="tel:{{HOTLINE NUMBER}}">{{HOTLINE NUMBER}}</a>.<!-- FOR A PROD SITE: Replace {{HOTLINE NUMBER}} with a real SNAP assistance hotline number users can call. -->
     </footer>
   </body>

--- a/prescreeners/shared/css/custom-styles.css
+++ b/prescreeners/shared/css/custom-styles.css
@@ -121,7 +121,7 @@ fieldset.usa-fieldset legend {
 
 /* Footer styles */
 
-footer {
+footer#snap-calculator-footer {
   color: white;
   background-color: #1B1349;
   text-align: center;
@@ -129,10 +129,10 @@ footer {
   padding: 16px;
 }
 
-footer a {
+footer#snap-calculator-footer a {
   color: white;
 }
 
-footer div {
+footer#snap-calculator-footer div {
   margin: 16px 0;
 }

--- a/prescreeners/va.html
+++ b/prescreeners/va.html
@@ -306,7 +306,7 @@
         <div class="tablet:grid-col"></div>
       </div>
     </div>
-    <footer>
+    <footer id="snap-calculator-footer">
       Questions about your result? Confused about anything on this form? Reach out: <a href="tel:{{HOTLINE NUMBER}}">{{HOTLINE NUMBER}}</a>.<!-- FOR A PROD SITE: Replace {{HOTLINE NUMBER}} with a real SNAP assistance hotline number users can call. -->
     </footer>
   </body>


### PR DESCRIPTION
... since websites likely have their own `<footer>` styles and we wouldn't want to override those. 