### PR TITLE
Emphasize monthly income fields using underlining

### DIFF
--- a/prescreeners/il.html
+++ b/prescreeners/il.html
@@ -137,7 +137,7 @@
             </div>
 
             <label class="usa-label" for="monthly_job_income">
-              <strong>Monthly</strong> household pre-tax income from jobs or self-employment
+              <u>Monthly</u> household pre-tax income from jobs or self-employment
               <span class="field-required">
                 *required
               </span>
@@ -153,7 +153,7 @@
             </div>
 
             <label class="usa-label" for="monthly_non_job_income">
-              <strong>Monthly</strong> household income from other sources
+              <u>Monthly</u> household income from other sources
               <span class="field-required">
                 *required
               </span>

--- a/prescreeners/va.html
+++ b/prescreeners/va.html
@@ -137,7 +137,7 @@
             </div>
 
             <label class="usa-label" for="monthly_job_income">
-              <strong>Monthly</strong> household pre-tax income from jobs or self-employment
+              <u>Monthly</u> household pre-tax income from jobs or self-employment
               <span class="field-required">
                 *required
               </span>
@@ -153,7 +153,7 @@
             </div>
 
             <label class="usa-label" for="monthly_non_job_income">
-              <strong>Monthly</strong> household income from other sources
+              <u>Monthly</u> household income from other sources
               <span class="field-required">
                 *required
               </span>


### PR DESCRIPTION
# Note

These were previously emphasized using bolding based on usability testing — now that all field labels are bolded, we need a new way to emphasize. 

# Federalist preview link

https://federalist-1c734efa-8e7a-40ed-9b1e-432001a347e9.app.cloud.gov/preview/18f/snap-js-prescreener-prototypes/ars/underline-monthly-income/prescreeners/va.html

# Screenshot

<img width="352" alt="Screen Shot 2020-08-11 at 9 23 50 AM" src="https://user-images.githubusercontent.com/3209501/89909176-6565fb80-dbb4-11ea-8b1c-ca1356f5b5d8.png">
